### PR TITLE
add components to use latest revision of Android SDK Tools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ jdk: oraclejdk7
 
 android:
     components:
+        - platform-tools
+        - tools
         - android-23
         - build-tools-23.0.0
         - extra-android-support


### PR DESCRIPTION
Build is failing because you are using build-tools-23.0.0, which isn't part of pre-existing components. added lines 7,8 for the fix

see example .travis.yml for Android projects.
https://docs.travis-ci.com/user/languages/android
